### PR TITLE
Update to prepublish packages before deployments

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,3 +13,7 @@ steps:
     agents:
       queue: elastic
 
+  - name: ":pill:"
+    command: "bin/buildkite bin/ci run yarn lint"
+    agents:
+      queue: elastic

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,7 @@ WORKDIR $APP
 
 RUN npm i -g yarn
 
-ADD package.json package.json
-ADD yarn.lock yarn.lock
-RUN yarn
-
 ADD . ./
+RUN yarn
 
 CMD "/bin/bash"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "brb serve --client-config='./webpack.client.config'",
     "build": "brb build --client-config='./webpack.client.config'",
+    "lint": "brb lint",
+    "prepublish": "brb build && babel source --out-dir dist/modular",
     "test": "brb test",
     "test:watch": "brb test --watch"
   },
@@ -20,11 +22,6 @@
   },
   "homepage": "https://github.com/everydayhero/nps-collect#readme",
   "dependencies": {
-    "babel-core": "^6.17.0",
-    "babel-plugin-espower": "^2.3.1",
-    "babel-polyfill": "^6.16.0",
-    "babel-preset-latest": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
     "boiler-room-builder": "^1.0.0-11",
     "cxsync": "^1.0.9",
     "hero-ui": "^4.5.2",
@@ -35,6 +32,12 @@
     "react-radial-list": "1.3.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.17.0",
+    "babel-plugin-espower": "^2.3.1",
+    "babel-polyfill": "^6.16.0",
+    "babel-preset-latest": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
     "enzyme": "^2.4.1",
     "jsdom": "^9.6.0",
     "mocha": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "brb serve --client-config='./webpack.client.config'",
     "build": "brb build --client-config='./webpack.client.config'",
     "lint": "brb lint",
-    "prepublish": "brb build && babel source --out-dir dist/modular",
+    "prepublish": "brb build --client-config='./webpack.client.config' && babel source --out-dir dist/modular",
     "test": "brb test",
     "test:watch": "brb test --watch"
   },

--- a/source/components/NPSCollect/__tests__/NPSCollect-test.js
+++ b/source/components/NPSCollect/__tests__/NPSCollect-test.js
@@ -7,7 +7,6 @@ import 'sinon-as-promised'
 import * as data from '../../../data'
 import RatingButtonGroup from '../../RatingButtonGroup'
 import FeedbackSection from '../../FeedbackSection'
-import LoadingIndicator from '../../LoadingIndicator'
 import NPSCollect from '../'
 
 describe('NPSCollect container component', () => {

--- a/source/components/NPSCollect/index.js
+++ b/source/components/NPSCollect/index.js
@@ -8,7 +8,6 @@ import { sendNPSScore, sendNPSFeedback } from '../../data'
 import images from '../../images'
 import RatingButtonGroup from '../RatingButtonGroup'
 import FeedbackSection from '../FeedbackSection'
-import LoadingIndicator from '../LoadingIndicator'
 import Preamble from '../Preamble'
 import styles from './styles'
 

--- a/source/components/Preamble/__tests__/Preamble-test.js
+++ b/source/components/Preamble/__tests__/Preamble-test.js
@@ -42,7 +42,7 @@ describe('Preamble display component', () => {
     const wrapper = mount(<Preamble score={-1} />)
 
     assert(wrapper.text() ===
-      'Thank you for donating with Everydayhero. You\'re awesome!'
-      + 'If you have a second, we\'d value your feedback.')
+      'Thank you for donating with Everydayhero. You\'re awesome!' +
+      'If you have a second, we\'d value your feedback.')
   })
 })

--- a/source/components/SubmitButton/__tests__/SubmitButton-test.js
+++ b/source/components/SubmitButton/__tests__/SubmitButton-test.js
@@ -15,9 +15,9 @@ describe('SubmitButton display component', () => {
   })
 
   it('should render the button label', () => {
-    const wrapper = shallow(<SubmitButton handleClicked={noop} text="Wassup" />)
+    const wrapper = shallow(<SubmitButton handleClicked={noop} text='Wassup' />)
 
-    assert(wrapper.text() == "Wassup")
+    assert(wrapper.text() === 'Wassup')
   })
 
   it('should call handleClicked on click', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,6 +259,27 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
+babel-cli:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.18.0.tgz#92117f341add9dead90f6fa7d0a97c0cc08ec186"
+  dependencies:
+    babel-core "^6.18.0"
+    babel-polyfill "^6.16.0"
+    babel-register "^6.18.0"
+    babel-runtime "^6.9.0"
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.0.0"
+    glob "^5.0.5"
+    lodash "^4.2.0"
+    output-file-sync "^1.1.0"
+    path-is-absolute "^1.0.0"
+    slash "^1.0.0"
+    source-map "^0.5.0"
+    v8flags "^2.0.10"
+  optionalDependencies:
+    chokidar "^1.0.0"
+
 babel-code-frame@^6.16.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.16.0.tgz#f90e60da0862909d3ce098733b5d3987c97cb8de"
@@ -1380,7 +1401,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.5.0, commander@^2.9.0, commander@2.9.0:
+commander@^2.5.0, commander@^2.8.1, commander@^2.9.0, commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2563,6 +2584,10 @@ fresh@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
 
+fs-readdir-recursive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2656,7 +2681,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^5.0.15:
+glob@^5.0.15, glob@^5.0.5:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -2714,6 +2739,10 @@ globule@^1.0.0:
 graceful-fs@^4.1.2:
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.9.tgz#baacba37d19d11f9d146d3578bc99958c3787e29"
+
+graceful-fs@^4.1.4:
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.10.tgz#f2d720c22092f743228775c75e3612632501f131"
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -4157,6 +4186,14 @@ osenv@0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+output-file-sync@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
+  dependencies:
+    graceful-fs "^4.1.4"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.0"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -5771,6 +5808,10 @@ url@~0.10.1:
     punycode "1.3.2"
     querystring "0.2.0"
 
+user-home@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -5794,6 +5835,12 @@ utils-merge@1.0.0:
 uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+
+v8flags@^2.0.10:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.0.11.tgz#bca8f30f0d6d60612cc2c00641e6962d42ae6881"
+  dependencies:
+    user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This is a quick PR that will bundle packages before it goes to npm-land.

There is a bit of a penalty in the build pipeline that will need to be addressed as prepublish is run on each yarn/npm install so the whole project needs to be present